### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy -- -D warnings
+      - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,11 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `cargo build` — build the project
 - `cargo run` — build and run
 - `cargo check` — type-check without producing a binary
+- `cargo test` — run all tests
+- `cargo test <test_name>` — run a single test by name
 - `cargo clippy` — lint
-
-There are no tests in this project currently.
 
 ## What This Project Does
 

--- a/src/discord/api.rs
+++ b/src/discord/api.rs
@@ -46,3 +46,27 @@ pub async fn application_rpc(client_id: &str) -> Result<ApplicationRpcData, reqw
 
     Ok(data)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handshake_roundtrip() {
+        let handshake = Handshake {
+            v: 1,
+            client_id: String::from("123456789"),
+        };
+        let json = serde_json::to_string(&handshake).unwrap();
+        let parsed: Handshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.v, 1);
+        assert_eq!(parsed.client_id, "123456789");
+    }
+
+    #[test]
+    fn application_rpc_data_deserialize() {
+        let json = r#"{"name":"My App"}"#;
+        let data: ApplicationRpcData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.name, "My App");
+    }
+}

--- a/src/discord/ipc/error.rs
+++ b/src/discord/ipc/error.rs
@@ -24,3 +24,23 @@ impl From<IpcError> for std::io::Error {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipc_error_display() {
+        assert_eq!(format!("{}", IpcError::InvalidOpCode), "invalid opcode");
+        assert_eq!(format!("{}", IpcError::NoNameAvailable), "no name available");
+    }
+
+    #[test]
+    fn ipc_error_into_io_error() {
+        let io_err: std::io::Error = IpcError::InvalidOpCode.into();
+        assert_eq!(io_err.kind(), std::io::ErrorKind::Other);
+
+        let io_err: std::io::Error = IpcError::NoNameAvailable.into();
+        assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
+    }
+}

--- a/src/discord/ipc/error.rs
+++ b/src/discord/ipc/error.rs
@@ -19,7 +19,7 @@ impl std::error::Error for IpcError {}
 impl From<IpcError> for std::io::Error {
     fn from(value: IpcError) -> Self {
         match value {
-            IpcError::InvalidOpCode => std::io::Error::new(std::io::ErrorKind::Other, value),
+            IpcError::InvalidOpCode => std::io::Error::other(value),
             IpcError::NoNameAvailable => std::io::Error::new(std::io::ErrorKind::NotFound, value),
         }
     }

--- a/src/discord/ipc/mod.rs
+++ b/src/discord/ipc/mod.rs
@@ -151,3 +151,99 @@ pub fn path(name: &String) -> PathBuf {
     dir.push(name.clone());
     dir
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opcode_from_u32_valid() {
+        assert!(matches!(OpCode::from_u32(0), Ok(OpCode::Handshake)));
+        assert!(matches!(OpCode::from_u32(1), Ok(OpCode::Frame)));
+        assert!(matches!(OpCode::from_u32(2), Ok(OpCode::Close)));
+        assert!(matches!(OpCode::from_u32(3), Ok(OpCode::Ping)));
+        assert!(matches!(OpCode::from_u32(4), Ok(OpCode::Pong)));
+    }
+
+    #[test]
+    fn opcode_from_u32_invalid() {
+        assert!(matches!(OpCode::from_u32(5), Err(IpcError::InvalidOpCode)));
+        assert!(matches!(OpCode::from_u32(255), Err(IpcError::InvalidOpCode)));
+    }
+
+    #[test]
+    fn opcode_display() {
+        assert_eq!(format!("{}", OpCode::Handshake), "0");
+        assert_eq!(format!("{}", OpCode::Frame), "1");
+        assert_eq!(format!("{}", OpCode::Close), "2");
+        assert_eq!(format!("{}", OpCode::Ping), "3");
+        assert_eq!(format!("{}", OpCode::Pong), "4");
+    }
+
+    #[test]
+    fn data_len() {
+        let data = Data {
+            opcode: OpCode::Frame,
+            msg: String::from("hello"),
+        };
+        assert_eq!(data.len(), 5);
+    }
+
+    #[test]
+    fn data_to_buf_format() {
+        let data = Data {
+            opcode: OpCode::Frame,
+            msg: String::from("test"),
+        };
+        let buf = data.to_buf();
+        // 4 bytes opcode + 4 bytes length + 4 bytes message
+        assert_eq!(buf.len(), 12);
+
+        // Opcode: Frame = 1, little-endian
+        assert_eq!(&buf[0..4], &1u32.to_le_bytes());
+        // Length: 4, little-endian
+        assert_eq!(&buf[4..8], &4u32.to_le_bytes());
+        // Message payload
+        assert_eq!(&buf[8..], b"test");
+    }
+
+    #[test]
+    fn data_to_buf_empty_message() {
+        let data = Data {
+            opcode: OpCode::Handshake,
+            msg: String::new(),
+        };
+        let buf = data.to_buf();
+        assert_eq!(buf.len(), 8);
+        assert_eq!(&buf[0..4], &0u32.to_le_bytes());
+        assert_eq!(&buf[4..8], &0u32.to_le_bytes());
+    }
+
+    #[test]
+    fn data_to_json_value() {
+        let data = Data {
+            opcode: OpCode::Handshake,
+            msg: String::from(r#"{"v":1,"client_id":"123456"}"#),
+        };
+        let handshake: crate::discord::api::Handshake = data.to_json_value().unwrap();
+        assert_eq!(handshake.v, 1);
+        assert_eq!(handshake.client_id, "123456");
+    }
+
+    #[test]
+    fn data_to_json_value_invalid() {
+        let data = Data {
+            opcode: OpCode::Frame,
+            msg: String::from("not json"),
+        };
+        let result: Result<crate::discord::api::Handshake, _> = data.to_json_value();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn path_appends_name() {
+        let name = String::from("discord-ipc-0");
+        let result = path(&name);
+        assert!(result.ends_with("discord-ipc-0"));
+    }
+}

--- a/src/discord/ipc/mod.rs
+++ b/src/discord/ipc/mod.rs
@@ -75,11 +75,11 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(name: &String, channel: &(broadcast::Sender<Data>, broadcast::Receiver<Data>), switch_tx: mpsc::UnboundedSender<Data>) -> Client {
+    pub fn new(name: &str, channel: &(broadcast::Sender<Data>, broadcast::Receiver<Data>), switch_tx: mpsc::UnboundedSender<Data>) -> Client {
         let (tx, rx) = channel;
 
         Client {
-            name: name.clone(),
+            name: name.to_owned(),
             channel: (tx.clone(), rx.resubscribe()),
             switch_tx,
         }
@@ -146,9 +146,9 @@ pub fn dir() -> PathBuf {
     PathBuf::from(r"\\.\pipe")
 }
 
-pub fn path(name: &String) -> PathBuf {
+pub fn path(name: &str) -> PathBuf {
     let mut dir = dir();
-    dir.push(name.clone());
+    dir.push(name);
     dir
 }
 

--- a/src/switch/ipc/error.rs
+++ b/src/switch/ipc/error.rs
@@ -14,3 +14,13 @@ impl fmt::Display for SwitchError {
 }
 
 impl std::error::Error for SwitchError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn switch_error_display() {
+        assert_eq!(format!("{}", SwitchError::NoDiscords), "no Discord IPCs available");
+    }
+}

--- a/src/switch/ipc/mod.rs
+++ b/src/switch/ipc/mod.rs
@@ -140,7 +140,7 @@ impl Client {
         // Respond with pong
         let pong = Data {
             opcode: OpCode::Pong,
-            msg: String::from(format!("\"{}\"", OpCode::Pong))
+            msg: format!("\"{}\"", OpCode::Pong)
         };
         self.switch_tx.send(pong)?;
 


### PR DESCRIPTION
## Summary
- Add 14 unit tests covering `OpCode`, `Data`, `IpcError`, `SwitchError`, `Handshake`, and `ApplicationRpcData`
- Add GitHub Actions CI workflow that runs `cargo clippy` and `cargo test` on pushes to main and PRs
- Update CLAUDE.md with test commands

## Test plan
- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm all 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)