### PR TITLE
Add native Windows MSI packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cargo build --release
 
 Tagged releases publish `.rpm` and `.msi` builds to the [Releases](https://github.com/kramerc/presence-switch/releases) page. For unreleased changes, the [`Package`](.github/workflows/package.yml) workflow also produces dev artifacts on every push to `main` and every PR — download them from the workflow run's Artifacts section.
 
-To build packages locally:
+To build packages locally on Linux:
 
 ```sh
 scripts/package.sh rpm   # → target/generate-rpm/presence-switch-*.rpm
@@ -48,6 +48,15 @@ scripts/package.sh all
 ```
 
 See `scripts/package.sh --help` for the toolchain requirements.
+
+To build the MSI natively on Windows (MSVC toolchain, no cross-compile):
+
+```powershell
+pwsh scripts/package.ps1   # → target/wix/presence-switch-*.msi
+```
+
+It links with the WiX v3 toolset, downloading it to `%LOCALAPPDATA%` on first
+run if neither `$env:WIX` nor `candle.exe` is found.
 
 ### Linux (any RPM-based distro with systemd)
 

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -31,9 +31,22 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Native commands (cargo, candle, light, git diff-index on a dirty tree) signal
+# status via exit code, and we inspect $LASTEXITCODE after each one. Opt out of
+# PowerShell 7.4+'s default of turning a non-zero native exit into a terminating
+# error under $ErrorActionPreference='Stop' so those checks stay the single
+# source of truth and an expected non-zero (e.g. `git diff-index` reporting a
+# dirty tree) doesn't abort the script.
+$PSNativeCommandUseErrorActionPreference = $false
+
 # Pin the WiX v3 release used when auto-downloading. 3.14.1 is the last v3.
 $WixVersion = '3.14.1'
 $WixZipUrl  = 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip'
+
+# The MSI and the binary it wraps are both x64; build that target explicitly so
+# the architecture stays consistent on a non-x64 host (e.g. ARM64 Windows, where
+# `cargo build` would otherwise produce an aarch64 binary for an x64-marked MSI).
+$RustTarget = 'x86_64-pc-windows-msvc'
 
 function Write-Step([string]$Message) { Write-Host "==> $Message" -ForegroundColor Blue }
 function Write-Fail([string]$Message) { Write-Error $Message }
@@ -44,18 +57,27 @@ Set-Location $Root
 
 $Name = 'presence-switch'
 
-# Parse version from Cargo.toml ([package] version, first match).
-$Version = (Select-String -Path (Join-Path $Root 'Cargo.toml') -Pattern '^version\s*=\s*"([^"]+)"' |
-    Select-Object -First 1).Matches[0].Groups[1].Value
-if (-not $Version) { Write-Fail "Could not parse version from Cargo.toml" }
+# Parse version from Cargo.toml ([package] version, first match). Capture the
+# match first so a missing/renamed field yields the intended error rather than a
+# PropertyNotFoundException on $null under StrictMode.
+$VersionMatch = Select-String -Path (Join-Path $Root 'Cargo.toml') -Pattern '^version\s*=\s*"([^"]+)"' |
+    Select-Object -First 1
+if (-not $VersionMatch) { Write-Fail "Could not parse version from Cargo.toml" }
+$Version = $VersionMatch.Matches[0].Groups[1].Value
 
-# Short SHA with dirty marker, mirroring package.sh.
-$ShortSha = (& git rev-parse --short=7 HEAD 2>$null)
-if ($LASTEXITCODE -ne 0 -or -not $ShortSha) {
+# Short SHA with dirty marker, mirroring package.sh. git isn't a packaging
+# requirement (a source archive with vendored deps builds fine), so fall back to
+# 'nogit' when it's absent rather than letting CommandNotFoundException abort.
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     $ShortSha = 'nogit'
 } else {
-    & git diff-index --quiet HEAD -- 2>$null
-    if ($LASTEXITCODE -ne 0) { $ShortSha = "$ShortSha.dirty" }
+    $ShortSha = (& git rev-parse --short=7 HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $ShortSha) {
+        $ShortSha = 'nogit'
+    } else {
+        & git diff-index --quiet HEAD -- 2>$null
+        if ($LASTEXITCODE -ne 0) { $ShortSha = "$ShortSha.dirty" }
+    }
 }
 
 function Get-WixBinDir {
@@ -95,11 +117,24 @@ function Build-Msi {
         Write-Fail "cargo not found. Install rustup: https://rustup.rs"
     }
 
-    Write-Step "Compiling release binary (x86_64-pc-windows-msvc)"
-    & cargo build --release --locked
+    # Ensure the x64 target is available (it's the default on an x64 host, but
+    # not on ARM64 Windows) before building against it explicitly. Only when
+    # rustup manages the toolchain; a standalone cargo will surface a clear
+    # error from the build itself if the target std is missing.
+    if (Get-Command rustup -ErrorAction SilentlyContinue) {
+        $installed = (& rustup target list --installed 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $installed -notcontains $RustTarget) {
+            Write-Step "Adding rustup target $RustTarget"
+            & rustup target add $RustTarget
+            if ($LASTEXITCODE -ne 0) { Write-Fail "rustup target add $RustTarget failed" }
+        }
+    }
+
+    Write-Step "Compiling release binary ($RustTarget)"
+    & cargo build --release --locked --target $RustTarget
     if ($LASTEXITCODE -ne 0) { Write-Fail "cargo build failed" }
 
-    $exe = Join-Path $Root "target\release\$Name.exe"
+    $exe = Join-Path $Root "target\$RustTarget\release\$Name.exe"
     if (-not (Test-Path $exe)) { Write-Fail "Release binary not found at $exe" }
 
     $wixBin = Get-WixBinDir

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Native Windows packaging script for presence-switch.
+
+.DESCRIPTION
+    Windows-native counterpart to scripts/package.sh. Builds the release binary
+    with the MSVC toolchain (no mingw cross-compile) and links the MSI with the
+    WiX v3 toolset (candle + light), which consumes wix/main.wxs unchanged --
+    the same WiX 2006 schema that wixl reads on Linux.
+
+    WiX v3 is located in this order:
+      1. $env:WIX            (set by the official WiX 3 installer)
+      2. candle.exe on PATH
+      3. A per-user cache at %LOCALAPPDATA%\presence-switch\wix3, auto-downloaded
+         from the WiX GitHub release if not already present.
+
+.PARAMETER Target
+    msi (default) -- cross-platform RPM packaging lives in package.sh; on Windows
+    only the MSI target is meaningful.
+
+.EXAMPLE
+    pwsh scripts/package.ps1
+    pwsh scripts/package.ps1 msi
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('msi')]
+    [string]$Target = 'msi'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Pin the WiX v3 release used when auto-downloading. 3.14.1 is the last v3.
+$WixVersion = '3.14.1'
+$WixZipUrl  = 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip'
+
+function Write-Step([string]$Message) { Write-Host "==> $Message" -ForegroundColor Blue }
+function Write-Fail([string]$Message) { Write-Error $Message }
+
+# Repo root is the parent of this script's directory.
+$Root = Split-Path -Parent $PSScriptRoot
+Set-Location $Root
+
+$Name = 'presence-switch'
+
+# Parse version from Cargo.toml ([package] version, first match).
+$Version = (Select-String -Path (Join-Path $Root 'Cargo.toml') -Pattern '^version\s*=\s*"([^"]+)"' |
+    Select-Object -First 1).Matches[0].Groups[1].Value
+if (-not $Version) { Write-Fail "Could not parse version from Cargo.toml" }
+
+# Short SHA with dirty marker, mirroring package.sh.
+$ShortSha = (& git rev-parse --short=7 HEAD 2>$null)
+if ($LASTEXITCODE -ne 0 -or -not $ShortSha) {
+    $ShortSha = 'nogit'
+} else {
+    & git diff-index --quiet HEAD -- 2>$null
+    if ($LASTEXITCODE -ne 0) { $ShortSha = "$ShortSha.dirty" }
+}
+
+function Get-WixBinDir {
+    # 1. Official installer sets $env:WIX (with a trailing slash) pointing at the
+    #    install root; binaries live under bin\.
+    if ($env:WIX) {
+        $bin = Join-Path $env:WIX 'bin'
+        if (Test-Path (Join-Path $bin 'candle.exe')) { return $bin }
+    }
+
+    # 2. candle.exe already on PATH.
+    $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
+    if ($candle) { return (Split-Path -Parent $candle.Source) }
+
+    # 3. Per-user cache; download on first use.
+    $cache = Join-Path $env:LOCALAPPDATA "presence-switch\wix3\$WixVersion"
+    if (Test-Path (Join-Path $cache 'candle.exe')) { return $cache }
+
+    Write-Step "WiX v3 not found; downloading $WixVersion to $cache"
+    New-Item -ItemType Directory -Force -Path $cache | Out-Null
+    $zip = Join-Path $cache 'wix-binaries.zip'
+    # TLS 1.2 for older runners; modern Windows defaults are fine but explicit is safe.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri $WixZipUrl -OutFile $zip -UseBasicParsing
+    Expand-Archive -Path $zip -DestinationPath $cache -Force
+    Remove-Item $zip -Force
+    if (-not (Test-Path (Join-Path $cache 'candle.exe'))) {
+        Write-Fail "WiX download did not produce candle.exe in $cache"
+    }
+    return $cache
+}
+
+function Build-Msi {
+    Write-Step "Building MSI   name=$Name version=$Version sha=$ShortSha"
+
+    if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+        Write-Fail "cargo not found. Install rustup: https://rustup.rs"
+    }
+
+    Write-Step "Compiling release binary (x86_64-pc-windows-msvc)"
+    & cargo build --release --locked
+    if ($LASTEXITCODE -ne 0) { Write-Fail "cargo build failed" }
+
+    $exe = Join-Path $Root "target\release\$Name.exe"
+    if (-not (Test-Path $exe)) { Write-Fail "Release binary not found at $exe" }
+
+    $wixBin = Get-WixBinDir
+    $candle = Join-Path $wixBin 'candle.exe'
+    $light  = Join-Path $wixBin 'light.exe'
+
+    $outDir = Join-Path $Root 'target\wix'
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    $wixobj = Join-Path $outDir 'main.wixobj'
+    $msi    = Join-Path $outDir "$Name-$Version-$ShortSha.msi"
+
+    # candle compiles .wxs -> .wixobj. -dVersion / -dExePath supply the same
+    # preprocessor variables that `wixl -D` does, so wix/main.wxs is shared
+    # verbatim between the Linux and Windows builds.
+    Write-Step "Compiling WiX source (candle)"
+    & $candle -nologo -arch x64 `
+        "-dVersion=$Version" `
+        "-dExePath=$exe" `
+        -out $wixobj `
+        (Join-Path $Root 'wix\main.wxs')
+    if ($LASTEXITCODE -ne 0) { Write-Fail "candle failed" }
+
+    # light links .wixobj -> .msi. No UI extension: main.wxs intentionally uses
+    # no <UIRef> (see the note in the .wxs), so the stock progress UI is used.
+    #
+    # -sval disables ICE validation. wixl (the Linux linker this build mirrors)
+    # runs no ICE validation at all, so the shared wix/main.wxs is authored
+    # against wixl's behavior. Native light otherwise fails ICE38 on the
+    # per-user MainExecutable component, whose file KeyPath is split from its
+    # HKCU registry KeyPath into a sibling component by design (see the comments
+    # in main.wxs). -sval makes light produce the same MSI wixl does.
+    Write-Step "Linking MSI (light)"
+    & $light -nologo -sval -out $msi $wixobj
+    if ($LASTEXITCODE -ne 0) { Write-Fail "light failed" }
+
+    Write-Step "Built MSI: $msi"
+}
+
+switch ($Target) {
+    'msi'   { Build-Msi }
+    default { Write-Fail "Unknown target: $Target" }
+}


### PR DESCRIPTION
## Summary

Adds `scripts/package.ps1`, a Windows-native counterpart to `scripts/package.sh`, so the MSI can be built on Windows without the Linux mingw cross-compile.

The script:
- Builds the release binary with the **MSVC** toolchain (`cargo build --release --locked`).
- Locates WiX v3 via `$env:WIX` -> `candle.exe` on PATH -> a per-user cache, **auto-downloading WiX 3.14.1** to `%LOCALAPPDATA%\presence-switch\wix3` on first run.
- Links the MSI with `candle` + `light`, reusing [`wix/main.wxs`](wix/main.wxs) unchanged via the same `-dVersion`/`-dExePath` preprocessor variables `wixl` passes.

```powershell
pwsh scripts/package.ps1   # -> target/wix/presence-switch-*.msi
```

## Why `-sval`

Native `light` runs ICE validation that `wixl` skips entirely, and `main.wxs`'s per-user `MainExecutable` component (file KeyPath split from its HKCU registry KeyPath into a sibling component, by design) trips **ICE38**. Passing `light -sval` disables validation so native `light` produces the same MSI `wixl` does, keeping the shared `.wxs` authored against `wixl`'s behavior.

## Verification

Ran the script end-to-end and opened the resulting MSI as a Windows Installer database:
- `ProductVersion = 0.1.0` (threaded from `Cargo.toml`), `UpgradeCode` matches `main.wxs`, `Manufacturer = Kramer Campbell`
- All 4 components present (`MainExecutable`, `MainExecutableRegistry`, `AutostartRegistry`, `ApplicationShortcut`)
- `WIX_UPGRADE_DETECTED`/`WIX_DOWNGRADE_DETECTED` confirm `MajorUpgrade` is wired in

The Linux cross-compile CI job is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)